### PR TITLE
Tags update

### DIFF
--- a/aws/TGW-VPC/bootstrap.tf
+++ b/aws/TGW-VPC/bootstrap.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "bootstrap_bucket" {
   acl           = "private"
   force_destroy = true
 
-  tags {
+  tags = {
     Name = "bootstrap_bucket"
   }
 }

--- a/aws/TGW-VPC/bootstrap2.tf
+++ b/aws/TGW-VPC/bootstrap2.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "bootstrap_bucket2" {
   acl           = "private"
   force_destroy = true
 
-  tags {
+  tags = {
     Name = "bootstrap_bucket2"
   }
 }

--- a/aws/TGW-VPC/tgw.tf
+++ b/aws/TGW-VPC/tgw.tf
@@ -6,7 +6,7 @@ resource "aws_ec2_transit_gateway" "tgw" {
   dns_support                     = "enable"
   auto_accept_shared_attachments  = "disable"
 
-  tags {
+  tags = {
     Name = "transit_gateway"
   }
 }
@@ -14,7 +14,7 @@ resource "aws_ec2_transit_gateway" "tgw" {
 resource "aws_ec2_transit_gateway_route_table" "tgw_security" {
   transit_gateway_id = "${aws_ec2_transit_gateway.tgw.id}"
 
-  tags {
+  tags = {
     Name = "tgw-rtb-security"
   }
 }
@@ -22,7 +22,7 @@ resource "aws_ec2_transit_gateway_route_table" "tgw_security" {
 resource "aws_ec2_transit_gateway_route_table" "tgw_spokes" {
   transit_gateway_id = "${aws_ec2_transit_gateway.tgw.id}"
 
-  tags {
+  tags = {
     Name = "tgw-rtb-spokes"
   }
 }
@@ -45,7 +45,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "tgw_security" {
   transit_gateway_default_route_table_association = false
   transit_gateway_default_route_table_propagation = false
 
-  tags {
+  tags = {
     Name = "tgw_attachment_security"
   }
 }

--- a/aws/TGW-VPC/vm-series/main.tf
+++ b/aws/TGW-VPC/vm-series/main.tf
@@ -74,7 +74,7 @@ resource "aws_network_interface" "eni-management" {
   security_groups   = ["${var.management_security_group_id}"]
   source_dest_check = true
 
-  tags {
+  tags = {
     Name = "eni_${var.name}_management"
   }
 }
@@ -85,7 +85,7 @@ resource "aws_network_interface" "eni-trust" {
   security_groups   = ["${var.trust_security_group_id}"]
   source_dest_check = false
 
-  tags {
+  tags = {
     Name = "eni_${var.name}_trust"
   }
 }
@@ -98,7 +98,7 @@ resource "aws_eip" "eip-management" {
   vpc               = true
   network_interface = "${aws_network_interface.eni-management.id}"
 
-  tags {
+  tags = {
     Name = "eip_${var.name}_management"
   }
 }
@@ -109,7 +109,7 @@ resource "aws_network_interface" "eni-untrust" {
   security_groups   = ["${var.untrust_security_group_id}"]
   source_dest_check = false
 
-  tags {
+  tags = {
     Name = "eni_${var.name}_untrust"
   }
 }
@@ -118,7 +118,7 @@ resource "aws_eip" "eip-untrust" {
   vpc               = true
   network_interface = "${aws_network_interface.eni-untrust.id}"
 
-  tags {
+  tags = {
     Name = "eip_${var.name}_untrust"
   }
 }
@@ -151,7 +151,7 @@ resource "aws_instance" "instance-ngfw" {
     network_interface_id = "${aws_network_interface.eni-trust.id}"
   }
 
-  tags {
+  tags = {
     Name = "${var.name}"
   }
 }

--- a/aws/TGW-VPC/vpc_security.tf
+++ b/aws/TGW-VPC/vpc_security.tf
@@ -3,7 +3,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "vpc_security" {
   cidr_block = "${var.vpc_security_cidr}"
 
-  tags {
+  tags = {
     Name = "vpc_security"
   }
 }
@@ -13,7 +13,7 @@ resource "aws_subnet" "vpc_security_public_1" {
   cidr_block        = "${var.vpc_security_subnet_public_1}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
-  tags {
+  tags = {
     Name = "vpc_security_public_1"
   }
 }
@@ -23,7 +23,7 @@ resource "aws_subnet" "vpc_security_public_2" {
   cidr_block        = "${var.vpc_security_subnet_public_2}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
 
-  tags {
+  tags = {
     Name = "vpc_security_public_2"
   }
 }
@@ -33,7 +33,7 @@ resource "aws_subnet" "vpc_security_private_1" {
   cidr_block        = "${var.vpc_security_subnet_private_1}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
-  tags {
+  tags = {
     Name = "vpc_security_private_1"
   }
 }
@@ -43,7 +43,7 @@ resource "aws_subnet" "vpc_security_private_2" {
   cidr_block        = "${var.vpc_security_subnet_private_2}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
 
-  tags {
+  tags = {
     Name = "vpc_security_private_2"
   }
 }
@@ -53,7 +53,7 @@ resource "aws_subnet" "vpc_security_tgw_1" {
   cidr_block        = "${var.vpc_security_subnet_tgw_1}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
-  tags {
+  tags = {
     Name = "vpc_security_tgw_1"
   }
 }
@@ -63,7 +63,7 @@ resource "aws_subnet" "vpc_security_tgw_2" {
   cidr_block        = "${var.vpc_security_subnet_tgw_2}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
 
-  tags {
+  tags = {
     Name = "vpc_security_tgw_2"
   }
 }
@@ -71,7 +71,7 @@ resource "aws_subnet" "vpc_security_tgw_2" {
 resource "aws_route_table" "vpc_security_tgw_1" {
   vpc_id = "${aws_vpc.vpc_security.id}"
 
-  tags {
+  tags = {
     Name = "tgw_1"
   }
 }
@@ -79,7 +79,7 @@ resource "aws_route_table" "vpc_security_tgw_1" {
 resource "aws_route_table" "vpc_security_tgw_2" {
   vpc_id = "${aws_vpc.vpc_security.id}"
 
-  tags {
+  tags = {
     Name = "tgw_2"
   }
 }
@@ -87,7 +87,7 @@ resource "aws_route_table" "vpc_security_tgw_2" {
 resource "aws_route_table" "vpc_security_private_1" {
   vpc_id = "${aws_vpc.vpc_security.id}"
 
-  tags {
+  tags = {
     Name = "private_1"
   }
 }
@@ -95,7 +95,7 @@ resource "aws_route_table" "vpc_security_private_1" {
 resource "aws_route_table" "vpc_security_private_2" {
   vpc_id = "${aws_vpc.vpc_security.id}"
 
-  tags {
+  tags = {
     Name = "private_2"
   }
 }
@@ -159,7 +159,7 @@ resource "aws_route" "vpc_security_trust_2_0" {
 resource "aws_internet_gateway" "vpc_security_igw" {
   vpc_id = "${aws_vpc.vpc_security.id}"
 
-  tags {
+  tags = {
     Name = "vpc_securty_igw"
   }
 }

--- a/aws/TGW-VPC/vpc_spoke/main.tf
+++ b/aws/TGW-VPC/vpc_spoke/main.tf
@@ -45,7 +45,7 @@ variable server2name {
 resource "aws_vpc" "vpc_spoke" {
   cidr_block = "${var.vpc_spoke_cidr}"
 
-  tags {
+  tags = {
     Name = "vpc_spoke_${var.vpc_spoke_cidr}"
   }
 }
@@ -57,7 +57,7 @@ resource "aws_subnet" "primary" {
   cidr_block        = "${var.vpc_spoke_subnet_cidr}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
-  tags {
+  tags = {
     Name = "vpc_spokeA_${var.vpc_spoke_subnet_cidr}"
   }
 }
@@ -67,7 +67,7 @@ resource "aws_subnet" "secondary" {
   cidr_block        = "${var.vpc_spoke_subnet2_cidr}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
 
-  tags {
+  tags = {
     Name = "vpc_spokeB_${var.vpc_spoke_subnet2_cidr}"
   }
 }
@@ -123,7 +123,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "tgw_spoke_attachment" {
   transit_gateway_default_route_table_association = false
   transit_gateway_default_route_table_propagation = false
 
-  tags {
+  tags = {
     Name = "tgw_attachment_spoke_${var.vpc_spoke_cidr}"
   }
 }


### PR DESCRIPTION
When using the templates in this repo today, it seems newer version(s) of Terraform want to use `tags = {}` (where previously `tags {}` was valid). Terraform v0.13.4 error message was:

```
Error: Unsupported block type

  on vpc_spoke/main.tf line 48, in resource "aws_vpc" "vpc_spoke":
  48:   tags {

Blocks of type "tags" are not expected here.
```

The edits in this PR solved it for me, so I figured I'd suggest them for the repo. I'm an SE so find me on Slack if anything I did was wrong :-) 

Cheers, James